### PR TITLE
Add Static Web App configuration

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/images/*.{png,jpg,gif}", "/css/*"]
+  }
+}


### PR DESCRIPTION
This PR adds the `staticwebapp.config.json` configuration file required for Azure Static Web Apps deployment.

The configuration includes:
- Navigation fallback to `/index.html` for client-side routing
- Exclusions for static assets (images and CSS files)

This configuration ensures that the Angular application works correctly when deployed as a Static Web App.